### PR TITLE
Add possibility to use customized object mapper

### DIFF
--- a/src/main/java/org/camunda/community/zeebe/testutils/samples/JobHandlerImpl.java
+++ b/src/main/java/org/camunda/community/zeebe/testutils/samples/JobHandlerImpl.java
@@ -3,6 +3,8 @@ package org.camunda.community.zeebe.testutils.samples;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobHandler;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 import org.camunda.community.zeebe.testutils.stubs.ActivatedJobStub;
@@ -22,6 +24,13 @@ public class JobHandlerImpl implements JobHandler {
         final Map<String, Object> variables = new HashMap<>();
         variables.put("key", "value");
         client.newCompleteCommand(job.getKey()).variables(variables).send().join();
+        break;
+      case COMPLETE_JOB_WITH_VARIABLES_AND_CUSTOM_MAPPER:
+        final Map<String, Object> variables2 = new HashMap<>();
+        variables2.put(
+            "offsetdatetime",
+            OffsetDateTime.of(2023, 10, 20, 6, 43, 23, 0, ZoneOffset.of("+02:00")));
+        client.newCompleteCommand(job.getKey()).variables(variables2).send().join();
         break;
       case FAIL_JOB:
         client.newFailCommand(job.getKey()).retries(3).errorMessage("job failed").send().join();
@@ -44,6 +53,7 @@ public class JobHandlerImpl implements JobHandler {
   public enum Scenario {
     COMPLETE_JOB_NO_VARIABLES,
     COMPLETE_JOB_WITH_VARIABLES,
+    COMPLETE_JOB_WITH_VARIABLES_AND_CUSTOM_MAPPER,
     FAIL_JOB,
     THROW_ERROR,
     COMMAND_REJECTED_JOB_NOT_FOUND;

--- a/src/main/java/org/camunda/community/zeebe/testutils/stubs/CompleteJobCommandStep1Stub.java
+++ b/src/main/java/org/camunda/community/zeebe/testutils/stubs/CompleteJobCommandStep1Stub.java
@@ -11,19 +11,20 @@ import java.time.Duration;
 class CompleteJobCommandStep1Stub extends CommandWithVariables<CompleteJobCommandStep1>
     implements CompleteJobCommandStep1 {
 
-  private static final ZeebeObjectMapper JSON_MAPPER = new ZeebeObjectMapper();
+  private final ZeebeObjectMapper mapper;
 
   private final ActivatedJobStub job;
 
-  CompleteJobCommandStep1Stub(final ActivatedJobStub job) {
-    super(JSON_MAPPER);
+  CompleteJobCommandStep1Stub(final ActivatedJobStub job, final ZeebeObjectMapper mapper) {
+    super(mapper);
+    this.mapper = mapper;
     this.job = job;
   }
 
   @Override
   protected CompleteJobCommandStep1 setVariablesInternal(final String variables) {
     if (job != null) {
-      job.setOutputVariables(JSON_MAPPER.fromJsonAsMap(variables));
+      job.setOutputVariables(mapper.fromJsonAsMap(variables));
     }
     return this;
   }

--- a/src/main/java/org/camunda/community/zeebe/testutils/stubs/JobClientStub.java
+++ b/src/main/java/org/camunda/community/zeebe/testutils/stubs/JobClientStub.java
@@ -1,10 +1,12 @@
 package org.camunda.community.zeebe.testutils.stubs;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
 import io.camunda.zeebe.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -14,10 +16,19 @@ public class JobClientStub implements JobClient {
   private static final AtomicLong counter = new AtomicLong();
 
   private final Map<Long, ActivatedJobStub> activatedJobs = new ConcurrentHashMap<>();
+  private final ZeebeObjectMapper mapper;
+
+  public JobClientStub() {
+    this.mapper = new ZeebeObjectMapper();
+  }
+
+  public JobClientStub(ObjectMapper mapper) {
+    this.mapper = new ZeebeObjectMapper(mapper);
+  }
 
   @Override
   public CompleteJobCommandStep1 newCompleteCommand(final long jobKey) {
-    return new CompleteJobCommandStep1Stub(takeJob(jobKey));
+    return new CompleteJobCommandStep1Stub(takeJob(jobKey), mapper);
   }
 
   @Override

--- a/src/test/java/org/camunda/community/zeebe/testutils/samples/OffsetDateTimeSerializer.java
+++ b/src/test/java/org/camunda/community/zeebe/testutils/samples/OffsetDateTimeSerializer.java
@@ -1,0 +1,25 @@
+package org.camunda.community.zeebe.testutils.samples;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class OffsetDateTimeSerializer extends JsonSerializer<OffsetDateTime> {
+
+  private static final DateTimeFormatter DATE_TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyyMMdd HHmmss XXX");
+
+  @Override
+  public void serialize(
+      OffsetDateTime value, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    if (value == null) {
+      jsonGenerator.writeNull();
+    } else {
+      jsonGenerator.writeString(DATE_TIME_FORMATTER.format(value));
+    }
+  }
+}


### PR DESCRIPTION
In our case, the Camunda variables contained an OffsetDateTime field. This cannot be mapped by the standard object mapper.

I've added the ability to use a custom object mapper to deal with this and similar situations.
